### PR TITLE
Implement market translator

### DIFF
--- a/src/utils/marketTranslator.js
+++ b/src/utils/marketTranslator.js
@@ -1,6 +1,36 @@
+const { similarity } = require('./matchMapper');
+
+const MARKET_MAP = {
+  'GG': 'Both Teams To Score - Yes',
+  'Over 2.5': 'Total Goals Over 2.5',
+};
+
+/**
+ * Translate a Bet9ja market description to the closest Betway equivalent.
+ * If an exact mapping isn't found, the most similar known market is used.
+ *
+ * @param {string} bet9jaMarket - Market string scraped from Bet9ja
+ * @returns {string} Betway market name
+ */
 function translateMarket(bet9jaMarket) {
-  // Placeholder for translating Bet9ja market codes to Betway equivalents
-  return bet9jaMarket;
+  if (!bet9jaMarket) return '';
+
+  if (MARKET_MAP[bet9jaMarket]) {
+    return MARKET_MAP[bet9jaMarket];
+  }
+
+  let bestKey = null;
+  let bestScore = -1;
+
+  for (const key of Object.keys(MARKET_MAP)) {
+    const score = similarity(bet9jaMarket.toLowerCase(), key.toLowerCase());
+    if (score > bestScore) {
+      bestScore = score;
+      bestKey = key;
+    }
+  }
+
+  return MARKET_MAP[bestKey] || bet9jaMarket;
 }
 
 module.exports = { translateMarket };


### PR DESCRIPTION
## Summary
- implement `translateMarket` for basic Bet9ja ➝ Betway mapping

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853fb7630388329a721d319c4be87de