### PR TITLE
Implement Betway converter

### DIFF
--- a/src/services/betwayConverter.js
+++ b/src/services/betwayConverter.js
@@ -1,20 +1,46 @@
-const axios = require('axios');
-const { mapMatches } = require('../utils/matchMapper');
 const { translateMarket } = require('../utils/marketTranslator');
 
+/**
+ * Convert a Bet9ja bet slip into a Betway compatible format.
+ * A simple pre-filled URL is generated using the converted bets.
+ *
+ * @param {Object} betSlip - Bet9ja bet slip { bookingCode, bets }
+ * @returns {Object} structured bet slip for Betway
+ */
 async function convertToBetway(betSlip) {
-  // Placeholder conversion logic
-  const convertedBets = betSlip.bets.map(bet => ({
-    homeTeam: bet.homeTeam,
-    awayTeam: bet.awayTeam,
-    market: translateMarket(bet.market),
-    odds: bet.odds
-  }));
+  if (!betSlip || !Array.isArray(betSlip.bets)) {
+    throw new Error('Invalid bet slip supplied');
+  }
 
-  // Example: would send data to Betway API here
+  const bets = betSlip.bets.map(bet => {
+    const translated = translateMarket(bet.market);
+    let market = translated;
+    let selection = '';
+
+    // Split market and selection if provided in the translator output
+    if (typeof translated === 'string' && translated.includes(' - ')) {
+      const parts = translated.split(' - ');
+      market = parts[0];
+      selection = parts[1] || '';
+    }
+
+    return {
+      homeTeam: bet.homeTeam,
+      awayTeam: bet.awayTeam,
+      market,
+      selection,
+    };
+  });
+
+  // Generate a naive pre-filled URL representation
+  const urlBase = 'https://www.betway.com.ng/betslip?bets=';
+  const url = urlBase + encodeURIComponent(JSON.stringify(bets));
+
   return {
-    bookingCode: betSlip.bookingCode,
-    bets: convertedBets
+    platform: 'Betway',
+    status: 'converted',
+    bets,
+    url,
   };
 }
 


### PR DESCRIPTION
## Summary
- implement betwayConverter to structure bet slip output
- generate a simple pre-filled Betway URL

## Testing
- `npm test` *(fails: no test specified)*
- `node -e "require('./src/services/betwayConverter').convertToBetway({bookingCode: '123', bets: [{homeTeam:'Chelsea', awayTeam:'Arsenal', market:'GG'}]}).then(r=>console.log(JSON.stringify(r,null,2))).catch(e=>console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_6853fd4f50788329a6772a3604ca99ef