### PR TITLE
Add basic frontend and error handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Heroscore Converter</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    label { display: block; margin-top: 10px; }
+    input, select { padding: 5px; margin-top: 5px; }
+    button { margin-top: 10px; padding: 6px 10px; }
+    pre { background: #f4f4f4; padding: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Bet Slip Converter</h1>
+  <form id="convertForm">
+    <label>
+      Platform From:
+      <select id="platformFrom">
+        <option value="bet9ja">Bet9ja</option>
+      </select>
+    </label>
+    <label>
+      Platform To:
+      <select id="platformTo">
+        <option value="betway">Betway</option>
+      </select>
+    </label>
+    <label>
+      Booking Code:
+      <input type="text" id="bookingCode" required />
+    </label>
+    <button type="submit">Convert</button>
+  </form>
+  <div id="result"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,22 @@
+document.getElementById('convertForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+
+  const bookingCode = document.getElementById('bookingCode').value.trim();
+  const platformFrom = document.getElementById('platformFrom').value;
+  const platformTo = document.getElementById('platformTo').value;
+  const resultDiv = document.getElementById('result');
+  resultDiv.textContent = 'Converting...';
+
+  try {
+    const res = await fetch('/convert-ticket', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ bookingCode, platformFrom, platformTo })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Conversion failed');
+    resultDiv.innerHTML = `<pre>${JSON.stringify(data, null, 2)}</pre>`;
+  } catch (err) {
+    resultDiv.textContent = err.message;
+  }
+});

--- a/server.js
+++ b/server.js
@@ -8,6 +8,9 @@ const { convertToBetway } = require('./src/services/betwayConverter');
 const app = express();
 app.use(bodyParser.json());
 
+// Serve basic frontend
+app.use(express.static('public'));
+
 app.use('/api', converterRoutes);
 
 app.post('/convert-ticket', async (req, res) => {

--- a/src/services/betwayConverter.js
+++ b/src/services/betwayConverter.js
@@ -13,7 +13,13 @@ async function convertToBetway(betSlip) {
   }
 
   const bets = betSlip.bets.map(bet => {
+    if (!bet.homeTeam || !bet.awayTeam) {
+      throw new Error('Game not found on Betway');
+    }
     const translated = translateMarket(bet.market);
+    if (!translated || translated === bet.market) {
+      throw new Error(`Market not found on Betway: ${bet.market}`);
+    }
     let market = translated;
     let selection = '';
 


### PR DESCRIPTION
## Summary
- serve `public` folder as a basic frontend
- create simple HTML/JS interface to convert bet slips
- validate bets in `convertToBetway` for missing games and markets

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853ff8b5f548329a2fd340b235cd2eb