### PR TITLE
Add Betway automation and multi-platform support

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,6 @@
 PORT=3000
+
+# Betway credentials
+BETWAY_USERNAME=
+BETWAY_PASSWORD=
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # HEROSCORE
 This website is for BEtting
+
+## Betway Automation
+
+Set the following environment variables in the `.env` file to enable
+automatic login to Betway when placing bets:
+
+```
+BETWAY_USERNAME=your_username
+BETWAY_PASSWORD=your_password
+```
+
+Run the server with `npm start` and visit `http://localhost:3000`.
+You can convert booking codes from Bet9ja, 1xBet, Sportybet, Betnaija or
+Stake to Betway and optionally place the bet automatically.

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,10 @@
       Platform From:
       <select id="platformFrom">
         <option value="bet9ja">Bet9ja</option>
+        <option value="1xbet">1xBet</option>
+        <option value="sportybet">Sportybet</option>
+        <option value="betnaija">Betnaija</option>
+        <option value="stake">Stake</option>
       </select>
     </label>
     <label>
@@ -33,6 +37,7 @@
       <input type="text" id="bookingCode" required />
     </label>
     <button type="submit">Convert</button>
+    <button id="placeBetBtn">Place Bet</button>
   </form>
   <div id="result"></div>
   <script src="script.js"></script>

--- a/public/script.js
+++ b/public/script.js
@@ -20,3 +20,24 @@ document.getElementById('convertForm').addEventListener('submit', async (e) => {
     resultDiv.textContent = err.message;
   }
 });
+
+document.getElementById('placeBetBtn').addEventListener('click', async (e) => {
+  e.preventDefault();
+  const bookingCode = document.getElementById('bookingCode').value.trim();
+  const platformFrom = document.getElementById('platformFrom').value;
+  const resultDiv = document.getElementById('result');
+  resultDiv.textContent = 'Placing bet...';
+
+  try {
+    const res = await fetch('/place-bet', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ bookingCode, platformFrom })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Bet placement failed');
+    resultDiv.innerHTML = `<pre>${JSON.stringify(data, null, 2)}</pre>`;
+  } catch (err) {
+    resultDiv.textContent = err.message;
+  }
+});

--- a/server.js
+++ b/server.js
@@ -3,7 +3,12 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const converterRoutes = require('./src/routes/converterRoutes');
 const { scrapeBet9ja } = require('./src/services/bet9jaScraper');
+const { scrape1xBet } = require('./src/services/platforms/oneXBetScraper');
+const { scrapeSportybet } = require('./src/services/platforms/sportybetScraper');
+const { scrapeBetnaija } = require('./src/services/platforms/betnaijaScraper');
+const { scrapeStake } = require('./src/services/platforms/stakeScraper');
 const { convertToBetway } = require('./src/services/betwayConverter');
+const { placeBetOnBetway } = require('./src/services/betwayPlacer');
 
 const app = express();
 app.use(bodyParser.json());
@@ -22,17 +27,64 @@ app.post('/convert-ticket', async (req, res) => {
       .json({ error: 'platformFrom, platformTo and bookingCode are required' });
   }
 
-  if (platformFrom === 'bet9ja' && platformTo === 'betway') {
-    try {
-      const betSlip = await scrapeBet9ja(bookingCode);
-      const betwayData = await convertToBetway(betSlip);
-      return res.json(betwayData);
-    } catch (error) {
-      return res.status(500).json({ error: error.message });
-    }
+  const scrapers = {
+    bet9ja: scrapeBet9ja,
+    '1xbet': scrape1xBet,
+    sportybet: scrapeSportybet,
+    betnaija: scrapeBetnaija,
+    stake: scrapeStake,
+  };
+
+  const converters = {
+    betway: convertToBetway,
+  };
+
+  const scrapeFn = scrapers[platformFrom];
+  const convertFn = converters[platformTo];
+
+  if (!scrapeFn || !convertFn) {
+    return res.status(400).json({ error: 'Conversion not supported' });
   }
 
-  res.status(400).json({ error: 'Conversion not supported' });
+  try {
+    const betSlip = await scrapeFn(bookingCode);
+    const converted = await convertFn(betSlip);
+    return res.json(converted);
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+});
+
+app.post('/place-bet', async (req, res) => {
+  const { platformFrom, bookingCode } = req.body;
+
+  if (!platformFrom || !bookingCode) {
+    return res
+      .status(400)
+      .json({ error: 'platformFrom and bookingCode are required' });
+  }
+
+  const scrapers = {
+    bet9ja: scrapeBet9ja,
+    '1xbet': scrape1xBet,
+    sportybet: scrapeSportybet,
+    betnaija: scrapeBetnaija,
+    stake: scrapeStake,
+  };
+
+  const scrapeFn = scrapers[platformFrom];
+  if (!scrapeFn) {
+    return res.status(400).json({ error: 'Conversion not supported' });
+  }
+
+  try {
+    const betSlip = await scrapeFn(bookingCode);
+    const betwayData = await convertToBetway(betSlip);
+    await placeBetOnBetway(betwayData);
+    return res.json({ status: 'bet placed' });
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
 });
 
 const PORT = process.env.PORT || 3000;

--- a/src/services/betwayPlacer.js
+++ b/src/services/betwayPlacer.js
@@ -1,0 +1,39 @@
+const puppeteer = require('puppeteer');
+
+/**
+ * Log in to Betway and place the provided bet slip.
+ * @param {Object} betwayData - Data returned from convertToBetway
+ */
+async function placeBetOnBetway(betwayData) {
+  const { BETWAY_USERNAME, BETWAY_PASSWORD } = process.env;
+  if (!BETWAY_USERNAME || !BETWAY_PASSWORD) {
+    throw new Error('Betway credentials are not set');
+  }
+
+  const browser = await puppeteer.launch({ headless: 'new' });
+  const page = await browser.newPage();
+
+  try {
+    await page.goto('https://www.betway.com.ng/', { waitUntil: 'networkidle2' });
+
+    // Login sequence - selectors may need adjustment
+    await page.waitForSelector('#LoginForm_username');
+    await page.type('#LoginForm_username', BETWAY_USERNAME, { delay: 20 });
+    await page.type('#LoginForm_password', BETWAY_PASSWORD, { delay: 20 });
+    await page.click('button[type="submit"]');
+    await page.waitForNavigation({ waitUntil: 'networkidle2' });
+
+    // Open bet slip URL
+    if (betwayData.url) {
+      await page.goto(betwayData.url, { waitUntil: 'networkidle2' });
+      // Wait for betslip submit button - selector may vary
+      await page.waitForSelector('.betslip-submit');
+      await page.click('.betslip-submit');
+      await page.waitForTimeout(2000);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+module.exports = { placeBetOnBetway };

--- a/src/services/platforms/betnaijaScraper.js
+++ b/src/services/platforms/betnaijaScraper.js
@@ -1,0 +1,16 @@
+const puppeteer = require('puppeteer');
+
+async function scrapeBetnaija(bookingCode) {
+  // Placeholder implementation for Betnaija scraping
+  const browser = await puppeteer.launch({ headless: 'new' });
+  const page = await browser.newPage();
+  try {
+    const url = `https://www.betnaija.com/booking/${bookingCode}`;
+    await page.goto(url, { waitUntil: 'networkidle2' });
+    return { bookingCode, bets: [] };
+  } finally {
+    await browser.close();
+  }
+}
+
+module.exports = { scrapeBetnaija };

--- a/src/services/platforms/oneXBetScraper.js
+++ b/src/services/platforms/oneXBetScraper.js
@@ -1,0 +1,21 @@
+const puppeteer = require('puppeteer');
+
+async function scrape1xBet(bookingCode) {
+  // Placeholder implementation for 1xBet scraping
+  // TODO: replace selectors with real ones
+  const browser = await puppeteer.launch({ headless: 'new' });
+  const page = await browser.newPage();
+  try {
+    // Example URL structure - may differ
+    const url = `https://1xbet.ng/booking/${bookingCode}`;
+    await page.goto(url, { waitUntil: 'networkidle2' });
+
+    // In a real scraper you would parse the bet slip details
+    // Here we simply return an empty bet list for demonstration
+    return { bookingCode, bets: [] };
+  } finally {
+    await browser.close();
+  }
+}
+
+module.exports = { scrape1xBet };

--- a/src/services/platforms/sportybetScraper.js
+++ b/src/services/platforms/sportybetScraper.js
@@ -1,0 +1,16 @@
+const puppeteer = require('puppeteer');
+
+async function scrapeSportybet(bookingCode) {
+  // Placeholder implementation for Sportybet scraping
+  const browser = await puppeteer.launch({ headless: 'new' });
+  const page = await browser.newPage();
+  try {
+    const url = `https://www.sportybet.com/ng/sportybooking/${bookingCode}`;
+    await page.goto(url, { waitUntil: 'networkidle2' });
+    return { bookingCode, bets: [] };
+  } finally {
+    await browser.close();
+  }
+}
+
+module.exports = { scrapeSportybet };

--- a/src/services/platforms/stakeScraper.js
+++ b/src/services/platforms/stakeScraper.js
@@ -1,0 +1,16 @@
+const puppeteer = require('puppeteer');
+
+async function scrapeStake(bookingCode) {
+  // Placeholder implementation for Stake scraping
+  const browser = await puppeteer.launch({ headless: 'new' });
+  const page = await browser.newPage();
+  try {
+    const url = `https://stake.com/sports/booking/${bookingCode}`;
+    await page.goto(url, { waitUntil: 'networkidle2' });
+    return { bookingCode, bets: [] };
+  } finally {
+    await browser.close();
+  }
+}
+
+module.exports = { scrapeStake };


### PR DESCRIPTION
## Summary
- add environment variables for Betway credentials
- allow selecting multiple source platforms in UI
- add button to place bet automatically
- implement Betway automation using puppeteer
- stub scrapers for 1xBet, Sportybet, Betnaija and Stake
- add API endpoints to convert tickets and place bets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685401dcb5888329b98c46e016ef40e3