### PR TITLE
Add caching and logging utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ BETWAY_PASSWORD=your_password
 Run the server with `npm start` and visit `http://localhost:3000`.
 You can convert booking codes from Bet9ja, 1xBet, Sportybet, Betnaija or
 Stake to Betway and optionally place the bet automatically.
+
+## Important Notice
+
+This project interacts with third-party betting platforms. Ensure you comply
+with each platform's Terms of Service when using the provided scrapers and
+automation features.

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const { scrapeBetnaija } = require('./src/services/platforms/betnaijaScraper');
 const { scrapeStake } = require('./src/services/platforms/stakeScraper');
 const { convertToBetway } = require('./src/services/betwayConverter');
 const { placeBetOnBetway } = require('./src/services/betwayPlacer');
+const { log, error: logError } = require('./src/utils/logger');
 
 const app = express();
 app.use(bodyParser.json());
@@ -47,11 +48,13 @@ app.post('/convert-ticket', async (req, res) => {
   }
 
   try {
+    log(`Converting ${bookingCode} from ${platformFrom} to ${platformTo}`);
     const betSlip = await scrapeFn(bookingCode);
     const converted = await convertFn(betSlip);
     return res.json(converted);
-  } catch (error) {
-    return res.status(500).json({ error: error.message });
+  } catch (err) {
+    logError(err);
+    return res.status(500).json({ error: err.message });
   }
 });
 
@@ -78,16 +81,18 @@ app.post('/place-bet', async (req, res) => {
   }
 
   try {
+    log(`Placing bet from ${platformFrom} using code ${bookingCode}`);
     const betSlip = await scrapeFn(bookingCode);
     const betwayData = await convertToBetway(betSlip);
     await placeBetOnBetway(betwayData);
     return res.json({ status: 'bet placed' });
-  } catch (error) {
-    return res.status(500).json({ error: error.message });
+  } catch (err) {
+    logError(err);
+    return res.status(500).json({ error: err.message });
   }
 });
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
+  log(`Server running on port ${PORT}`);
 });

--- a/src/services/betwayPlacer.js
+++ b/src/services/betwayPlacer.js
@@ -1,4 +1,5 @@
 const puppeteer = require('puppeteer');
+const { log } = require('../utils/logger');
 
 /**
  * Log in to Betway and place the provided bet slip.
@@ -12,9 +13,11 @@ async function placeBetOnBetway(betwayData) {
 
   const browser = await puppeteer.launch({ headless: 'new' });
   const page = await browser.newPage();
+  log('Launching browser to place bet on Betway');
 
   try {
     await page.goto('https://www.betway.com.ng/', { waitUntil: 'networkidle2' });
+    log('Logging into Betway');
 
     // Login sequence - selectors may need adjustment
     await page.waitForSelector('#LoginForm_username');
@@ -26,6 +29,7 @@ async function placeBetOnBetway(betwayData) {
     // Open bet slip URL
     if (betwayData.url) {
       await page.goto(betwayData.url, { waitUntil: 'networkidle2' });
+      log('Submitting bet slip');
       // Wait for betslip submit button - selector may vary
       await page.waitForSelector('.betslip-submit');
       await page.click('.betslip-submit');

--- a/src/services/platforms/betnaijaScraper.js
+++ b/src/services/platforms/betnaijaScraper.js
@@ -1,13 +1,26 @@
 const puppeteer = require('puppeteer');
+const SimpleCache = require('../../utils/simpleCache');
+const { log } = require('../../utils/logger');
+
+const cache = new SimpleCache(5 * 60 * 1000);
 
 async function scrapeBetnaija(bookingCode) {
+  const cached = cache.get(bookingCode);
+  if (cached) {
+    log(`Betnaija cache hit for ${bookingCode}`);
+    return cached;
+  }
+
   // Placeholder implementation for Betnaija scraping
   const browser = await puppeteer.launch({ headless: 'new' });
   const page = await browser.newPage();
+  log(`Scraping Betnaija for ${bookingCode}`);
   try {
     const url = `https://www.betnaija.com/booking/${bookingCode}`;
     await page.goto(url, { waitUntil: 'networkidle2' });
-    return { bookingCode, bets: [] };
+    const result = { bookingCode, bets: [] };
+    cache.set(bookingCode, result);
+    return result;
   } finally {
     await browser.close();
   }

--- a/src/services/platforms/oneXBetScraper.js
+++ b/src/services/platforms/oneXBetScraper.js
@@ -1,10 +1,21 @@
 const puppeteer = require('puppeteer');
+const SimpleCache = require('../../utils/simpleCache');
+const { log } = require('../../utils/logger');
+
+const cache = new SimpleCache(5 * 60 * 1000);
 
 async function scrape1xBet(bookingCode) {
+  const cached = cache.get(bookingCode);
+  if (cached) {
+    log(`1xBet cache hit for ${bookingCode}`);
+    return cached;
+  }
+
   // Placeholder implementation for 1xBet scraping
   // TODO: replace selectors with real ones
   const browser = await puppeteer.launch({ headless: 'new' });
   const page = await browser.newPage();
+  log(`Scraping 1xBet for ${bookingCode}`);
   try {
     // Example URL structure - may differ
     const url = `https://1xbet.ng/booking/${bookingCode}`;
@@ -12,7 +23,9 @@ async function scrape1xBet(bookingCode) {
 
     // In a real scraper you would parse the bet slip details
     // Here we simply return an empty bet list for demonstration
-    return { bookingCode, bets: [] };
+    const result = { bookingCode, bets: [] };
+    cache.set(bookingCode, result);
+    return result;
   } finally {
     await browser.close();
   }

--- a/src/services/platforms/sportybetScraper.js
+++ b/src/services/platforms/sportybetScraper.js
@@ -1,13 +1,26 @@
 const puppeteer = require('puppeteer');
+const SimpleCache = require('../../utils/simpleCache');
+const { log } = require('../../utils/logger');
+
+const cache = new SimpleCache(5 * 60 * 1000);
 
 async function scrapeSportybet(bookingCode) {
+  const cached = cache.get(bookingCode);
+  if (cached) {
+    log(`Sportybet cache hit for ${bookingCode}`);
+    return cached;
+  }
+
   // Placeholder implementation for Sportybet scraping
   const browser = await puppeteer.launch({ headless: 'new' });
   const page = await browser.newPage();
+  log(`Scraping Sportybet for ${bookingCode}`);
   try {
     const url = `https://www.sportybet.com/ng/sportybooking/${bookingCode}`;
     await page.goto(url, { waitUntil: 'networkidle2' });
-    return { bookingCode, bets: [] };
+    const result = { bookingCode, bets: [] };
+    cache.set(bookingCode, result);
+    return result;
   } finally {
     await browser.close();
   }

--- a/src/services/platforms/stakeScraper.js
+++ b/src/services/platforms/stakeScraper.js
@@ -1,13 +1,26 @@
 const puppeteer = require('puppeteer');
+const SimpleCache = require('../../utils/simpleCache');
+const { log } = require('../../utils/logger');
+
+const cache = new SimpleCache(5 * 60 * 1000);
 
 async function scrapeStake(bookingCode) {
+  const cached = cache.get(bookingCode);
+  if (cached) {
+    log(`Stake cache hit for ${bookingCode}`);
+    return cached;
+  }
+
   // Placeholder implementation for Stake scraping
   const browser = await puppeteer.launch({ headless: 'new' });
   const page = await browser.newPage();
+  log(`Scraping Stake for ${bookingCode}`);
   try {
     const url = `https://stake.com/sports/booking/${bookingCode}`;
     await page.goto(url, { waitUntil: 'networkidle2' });
-    return { bookingCode, bets: [] };
+    const result = { bookingCode, bets: [] };
+    cache.set(bookingCode, result);
+    return result;
   } finally {
     await browser.close();
   }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_FILE = path.resolve(__dirname, '../../server.log');
+const ERROR_FILE = path.resolve(__dirname, '../../error.log');
+
+function log(message) {
+  const timestamp = new Date().toISOString();
+  const line = `[${timestamp}] ${message}\n`;
+  fs.appendFileSync(LOG_FILE, line);
+  console.log(line.trim());
+}
+
+function error(err) {
+  const timestamp = new Date().toISOString();
+  const line = `[${timestamp}] ERROR: ${err.stack || err}\n`;
+  fs.appendFileSync(ERROR_FILE, line);
+  console.error(line.trim());
+}
+
+module.exports = { log, error };

--- a/src/utils/simpleCache.js
+++ b/src/utils/simpleCache.js
@@ -1,0 +1,24 @@
+class SimpleCache {
+  constructor(ttl = 600000) {
+    this.ttl = ttl; // time to live in ms
+    this.store = new Map();
+  }
+
+  get(key) {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    const [value, expiry] = entry;
+    if (Date.now() > expiry) {
+      this.store.delete(key);
+      return null;
+    }
+    return value;
+  }
+
+  set(key, value) {
+    const expiry = Date.now() + this.ttl;
+    this.store.set(key, [value, expiry]);
+  }
+}
+
+module.exports = SimpleCache;


### PR DESCRIPTION
## Summary
- introduce reusable SimpleCache and logger utilities
- implement caching and logging in scraping services
- log actions and errors in main server
- document respect for platform Terms of Service

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685403ebaf848329b8e05f377fbd0544