### PR TITLE
Add /convert-ticket route

### DIFF
--- a/src/routes/converterRoutes.js
+++ b/src/routes/converterRoutes.js
@@ -17,4 +17,23 @@ router.post('/convert', async (req, res) => {
   }
 });
 
+// New route for converting a Bet9ja booking code directly to a Betway slip
+router.post('/convert-ticket', async (req, res) => {
+  const { bookingCode } = req.body;
+  if (!bookingCode) {
+    return res.status(400).json({ error: 'No code provided' });
+  }
+
+  try {
+    const bet9jaSlip = await scrapeBet9ja(bookingCode);
+    if (!bet9jaSlip) {
+      return res.status(500).json({ error: 'Failed to scrape booking code' });
+    }
+    const converted = convertToBetwayFormat(bet9jaSlip);
+    return res.json(converted);
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- add new `/convert-ticket` endpoint to convert Bet9ja booking codes to Betway slips

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68540aecda788329b6512c6b5d7887fa