### PR TITLE
Update converter routes to use new Bet9ja scraper alias

### DIFF
--- a/src/routes/converterRoutes.js
+++ b/src/routes/converterRoutes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { scrapeBet9ja } = require('../services/bet9jaScraper');
+const { scrapeBet9jaBooking } = require('../services/bet9jaScraper');
 const { convertToBetwayFormat } = require('../services/betwayConverter');
 
 router.post('/convert', async (req, res) => {
@@ -9,7 +9,7 @@ router.post('/convert', async (req, res) => {
     return res.status(400).json({ error: 'Booking code is required' });
   }
   try {
-    const betSlip = await scrapeBet9ja(bookingCode);
+    const betSlip = await scrapeBet9jaBooking(bookingCode);
     const betwayData = await convertToBetwayFormat(betSlip);
     res.json(betwayData);
   } catch (error) {
@@ -25,7 +25,7 @@ router.post('/convert-ticket', async (req, res) => {
   }
 
   try {
-    const bet9jaSlip = await scrapeBet9ja(bookingCode);
+    const bet9jaSlip = await scrapeBet9jaBooking(bookingCode);
     if (!bet9jaSlip) {
       return res.status(500).json({ error: 'Failed to scrape booking code' });
     }

--- a/src/services/bet9jaScraper.js
+++ b/src/services/bet9jaScraper.js
@@ -41,4 +41,11 @@ async function scrapeBet9ja(bookingCode) {
   return result;
 }
 
-module.exports = { scrapeBet9ja };
+async function scrapeBet9jaBooking(bookingCode) {
+  return scrapeBet9ja(bookingCode);
+}
+
+module.exports = {
+  scrapeBet9ja,
+  scrapeBet9jaBooking,
+};


### PR DESCRIPTION
## Summary
- expose `scrapeBet9jaBooking` alias in Bet9ja scraper
- use `scrapeBet9jaBooking` within `converterRoutes`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68540dbf834c8329a882d0e37403a996